### PR TITLE
[COD-36] Can register user when password confirmation is not passed backend (fixed)

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -3,6 +3,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  validates :last_name, :first_name, :email, :password, :password_confirmation, :role, presence: true
   enum :role, { student: 'STUDENT', teacher: 'TEACHER' }
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -3,12 +3,73 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  subject(:user1) do
-    described_class.create({ last_name: 'test', first_name: 'Pasha', email: 'test@mail.ru',
-                             password: 'testtest', password_confirmation: 'testtest', role: 'student' })
-  end
+  subject(:user) { described_class.create(user_params) }
+
+  let(:user_params) { { last_name:, first_name:, email:, password:, password_confirmation:, role: } }
+  let(:last_name) { 'Lastname' }
+  let(:first_name) { 'Firstname' }
+  let(:email) { 'test@mail.ru' }
+  let(:password) { 'testtest' }
+  let(:password_confirmation) { 'testtest' }
+  let(:role) { 'student' }
 
   it 'create users' do
-    expect(user1).to be_persisted
+    expect(user).to be_persisted
+  end
+
+  context "when last_name doesn't exist" do
+    let(:user_params) { { first_name:, email:, password:, password_confirmation:, role: } }
+
+    it "doesn't create user" do
+      expect(user).not_to be_persisted
+    end
+  end
+
+  context "when furst_name doesn't exist" do
+    let(:user_params) { { last_name:, email:, password:, password_confirmation:, role: } }
+
+    it "doesn't create user" do
+      expect(user).not_to be_persisted
+    end
+  end
+
+  context "when email doesn't exist" do
+    let(:user_params) { { last_name:, first_name:, password:, password_confirmation:, role: } }
+
+    it "doesn't create user" do
+      expect(user).not_to be_persisted
+    end
+  end
+
+  context "when password doesn't exist" do
+    let(:user_params) { { last_name:, first_name:, email:, password_confirmation:, role: } }
+
+    it "doesn't create user" do
+      expect(user).not_to be_persisted
+    end
+  end
+
+  context "when password_confirmation doesn't exist" do
+    let(:user_params) { { last_name:, first_name:, email:, password:, role: } }
+
+    it "doesn't create user" do
+      expect(user).not_to be_persisted
+    end
+  end
+
+  context "when role doesn't exist" do
+    let(:user_params) { { last_name:, first_name:, email:, password:, password_confirmation: } }
+
+    it "doesn't create user" do
+      expect(user).not_to be_persisted
+    end
+  end
+
+  context "when password and password_confirmation doesn't not match" do
+    let(:password_confirmation) { 'tsettset' }
+
+    it "doesn't create user" do
+      expect(user).not_to be_persisted
+    end
   end
 end

--- a/backend/spec/services/users/register_spec.rb
+++ b/backend/spec/services/users/register_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Users::Register do
     end
   end
 
-  context 'when password confirmation not passed', skip: 'TTD for bug' do
+  context 'when password confirmation not passed' do
     let(:params) do
       { email: 'test@gmail.com', password: 'qwerty123', firstName: 'testfirst',
         lastName: 'testlast', role: 'STUDENT' }


### PR DESCRIPTION
Fixed an issue when user could be created with unexisted fields
https://legolas.atlassian.net/browse/COD-36?atlOrigin=eyJpIjoiZmMwN2YyOTNiNDZkNDc1YmIzZTFiMTA4MzY5ZDQ1YWYiLCJwIjoiaiJ9
![Снимок экрана 2023-02-16 121837](https://user-images.githubusercontent.com/111079236/219321950-3afab07d-6890-4252-a92f-97eb7b4a19f4.png)
