### PR TITLE
Disabled RSpec/MultipleMemoizedHelpers in .rubocop.yml

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -20,3 +20,6 @@ Style/Documentation:
 AllCops:
   SuggestExtensions: true
   NewCops: enable
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false


### PR DESCRIPTION
RSpec/MultipleMemoizedHelpers is disabled