### PR TITLE
Update login step for Github workflow

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -14,8 +14,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Login to Github Container Registry
-      run: echo ${{ secrets.GH_TOKEN }} | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
+    - name: Login to GitHub Container registry
+      uses: docker/login-action@v1
+      with:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: ghcr.io
 
     - name: Fetch secrets from tawbar
       run: |


### PR DESCRIPTION
## Description
This PR supposed to fix deploy problem by changing "Login to github container registry" step.
Now we're passing `GITHUB_TOKEN` instead of private `GH_TOKEN` and `GHCR_USERNAME`

Actions used: [publish-docker](https://github.com/marketplace/actions/publish-docker)